### PR TITLE
Fix routing and env key handling

### DIFF
--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -1,15 +1,6 @@
-import { DashboardLayout } from "@/components/dashboard-layout"
+import { redirect } from "next/navigation"
+
 export default function HomePage() {
-  return (
-    <DashboardLayout>
-      <div className="space-y-8">
-        <div>
-          <h1 className="text-4xl font-bold bg-gradient-to-r from-[#00D4FF] to-[#00FF88] bg-clip-text text-transparent">
-            Dashboard
-          </h1>
-          <p className="text-muted-foreground mt-2">Welcome to the MJD platform</p>
-        </div>
-      </div>
-    </DashboardLayout>
-  )
+  redirect("/quotations")
+  return null
 }

--- a/client/app/register/page.tsx
+++ b/client/app/register/page.tsx
@@ -21,7 +21,7 @@ export default function RegisterPage() {
     e.preventDefault()
     try {
       await register(name,email,password,guests)
-      router.push("/")
+      router.push("/quotations")
     } catch (err) {
       setError("Registration failed")
     }

--- a/client/components/quotations/quotation-detail.tsx
+++ b/client/components/quotations/quotation-detail.tsx
@@ -99,7 +99,7 @@ export const QuotationDetail = memo(function QuotationDetail({ quotationId }: Qu
       {/* Header */}
       <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
         <div className="flex items-center space-x-4">
-          <Link href="/">
+          <Link href="/quotations">
             <Button variant="ghost" size="icon" className="hover:bg-white/10 ripple">
               <ArrowLeft className="h-5 w-5" />
             </Button>

--- a/client/contexts/api-keys-context.tsx
+++ b/client/contexts/api-keys-context.tsx
@@ -1,7 +1,6 @@
 "use client"
 
-import React, { createContext, useContext, useState, useEffect } from "react"
-import { useAuth } from "@/contexts/auth-context"
+import React, { createContext, useContext, useState } from "react"
 
 interface ApiKeyContextType {
   openaiKey: string
@@ -12,33 +11,17 @@ interface ApiKeyContextType {
 }
 
 const ApiKeyContext = createContext<ApiKeyContextType>({
-  openaiKey: "",
-  cohereKey: "",
-  geminiKey: "",
+  openaiKey: process.env.NEXT_PUBLIC_OPENAI_KEY ?? "",
+  cohereKey: process.env.NEXT_PUBLIC_COHERE_KEY ?? "",
+  geminiKey: process.env.NEXT_PUBLIC_GEMINI_KEY ?? "",
   setKeys: () => {},
   saveKeys: () => {}
 })
 
 export function ApiKeyProvider({children}:{children:React.ReactNode}){
-  const { user } = useAuth()
-  const uid = user?.id ?? 'guest'
-  const [openaiKey,setOpenai] = useState("")
-  const [cohereKey,setCohere] = useState("")
-  const [geminiKey,setGemini] = useState("")
-
-  useEffect(() => {
-    const stored = localStorage.getItem(`apiKeys_${uid}`)
-    if(stored){
-      const k = JSON.parse(stored)
-      setOpenai(k.openaiKey||"")
-      setCohere(k.cohereKey||"")
-      setGemini(k.geminiKey||"")
-    } else {
-      setOpenai("")
-      setCohere("")
-      setGemini("")
-    }
-  },[uid])
+  const [openaiKey,setOpenai] = useState(process.env.NEXT_PUBLIC_OPENAI_KEY ?? "")
+  const [cohereKey,setCohere] = useState(process.env.NEXT_PUBLIC_COHERE_KEY ?? "")
+  const [geminiKey,setGemini] = useState(process.env.NEXT_PUBLIC_GEMINI_KEY ?? "")
 
   const setKeys = (keys: Partial<{openaiKey:string;cohereKey:string;geminiKey:string}>) => {
     if(keys.openaiKey!==undefined) setOpenai(keys.openaiKey)
@@ -47,8 +30,7 @@ export function ApiKeyProvider({children}:{children:React.ReactNode}){
   }
 
   const saveKeys = () => {
-    const all = { openaiKey, cohereKey, geminiKey }
-    localStorage.setItem(`apiKeys_${uid}`, JSON.stringify(all))
+    // Keys are provided via environment variables in production
   }
 
   return (

--- a/client/lib/quotation-store.ts
+++ b/client/lib/quotation-store.ts
@@ -17,79 +17,29 @@ export interface Quotation {
   items: QuotationItem[]
 }
 
-const KEY = 'quotations'
 const base = process.env.NEXT_PUBLIC_API_URL ?? ''
 
 export async function loadQuotations(): Promise<Quotation[]> {
-  try {
-    const res = await fetch(`${base}/api/quotations`, { cache: 'no-store' })
-    if (res.ok) {
-      const data = (await res.json()) as Quotation[]
-      if (typeof localStorage !== 'undefined') {
-        localStorage.setItem(KEY, JSON.stringify(data))
-      }
-      return data
-    }
-  } catch {
-    // ignore network errors
-  }
-  if (typeof localStorage === 'undefined') return []
-  try {
-    const raw = localStorage.getItem(KEY)
-    return raw ? (JSON.parse(raw) as Quotation[]) : []
-  } catch {
-    return []
-  }
+  const res = await fetch(`${base}/api/quotations`, { cache: 'no-store' })
+  if (!res.ok) return []
+  return (await res.json()) as Quotation[]
 }
 
 export async function saveQuotation(q: Quotation) {
-  try {
-    await fetch(`${base}/api/quotations`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(q),
-    })
-  } catch {
-    // ignore network errors
-  }
-  if (typeof localStorage === 'undefined') return
-  const all = await loadQuotations()
-  const idx = all.findIndex(i => i.id === q.id)
-  if (idx >= 0) all[idx] = q
-  else all.push(q)
-  localStorage.setItem(KEY, JSON.stringify(all))
+  await fetch(`${base}/api/quotations`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(q),
+  })
 }
 
 export async function getQuotation(id: string): Promise<Quotation | undefined> {
-  try {
-    const res = await fetch(`${base}/api/quotations/${id}`, { cache: 'no-store' })
-    if (res.ok) {
-      const q = (await res.json()) as Quotation
-      if (typeof localStorage !== 'undefined') {
-        const all = await loadQuotations()
-        const idx = all.findIndex(i => i.id === q.id)
-        if (idx >= 0) all[idx] = q
-        else all.push(q)
-        localStorage.setItem(KEY, JSON.stringify(all))
-      }
-      return q
-    }
-  } catch {
-    // ignore
-  }
-  const all = await loadQuotations()
-  return all.find(q => q.id === id)
+  const res = await fetch(`${base}/api/quotations/${id}`, { cache: 'no-store' })
+  if (!res.ok) return undefined
+  return (await res.json()) as Quotation
 }
 
 export async function deleteQuotation(id: string) {
-  try {
-    await fetch(`${base}/api/quotations/${id}`, { method: 'DELETE' })
-  } catch {
-    // ignore
-  }
-  if (typeof localStorage === 'undefined') return
-  const all = await loadQuotations()
-  const updated = all.filter(q => q.id !== id)
-  localStorage.setItem(KEY, JSON.stringify(updated))
+  await fetch(`${base}/api/quotations/${id}`, { method: 'DELETE' })
 }
 

--- a/client/pricematch/README.md
+++ b/client/pricematch/README.md
@@ -2,8 +2,8 @@
 
 This folder contains standalone scripts for matching price list items to inquiry spreadsheets.
 
-- **v0** – Uses both OpenAI and Cohere APIs. Includes `openaipricematcher.py` and `coherepricematcher.py`.
-- **v1** – Uses only Cohere via `coherepricematcher.py`.
-- **v2** – Adds fuzzy fallback and optional taxonomy columns. Run `python pricematch/v2/coherepricematcher.py` to launch.
+- **v0** – Uses both OpenAI and Cohere APIs. Run `python client/pricematch/v0/openaipricematcher.py` or `python client/pricematch/v0/coherepricematcher.py`.
+- **v1** – Uses only Cohere via `python client/pricematch/v1/coherepricematcher.py`.
+- **v2** – Adds fuzzy fallback and optional taxonomy columns. Run `python client/pricematch/v2/coherepricematcher.py` to launch.
 
 Each script provides a simple Tkinter interface to load the inquiry Excel file and output the priced result.


### PR DESCRIPTION
## Summary
- redirect `/` to `/quotations`
- update registration redirect and quotation detail back link
- store API keys from environment variables instead of local storage
- persist quotations only in database
- update instructions for pricematch scripts

## Testing
- `npm test --prefix backend` *(fails: ENOENT Input.xlsx)*

------
https://chatgpt.com/codex/tasks/task_b_684c1a05304c832592ef40c14251b1a7