### PR TITLE
Fix async params in quotation route

### DIFF
--- a/client/app/quotations/[id]/page.tsx
+++ b/client/app/quotations/[id]/page.tsx
@@ -1,10 +1,15 @@
 import { DashboardLayout } from "@/components/dashboard-layout"
 import { QuotationDetail } from "@/components/quotation-detail"
 
-export default function QuotationDetailPage({ params }: { params: { id: string } }) {
+export default async function QuotationDetailPage({
+  params,
+}: {
+  params: { id: string }
+}) {
+  const { id } = await params
   return (
     <DashboardLayout>
-      <QuotationDetail quotationId={params.id} />
+      <QuotationDetail quotationId={id} />
     </DashboardLayout>
   )
 }


### PR DESCRIPTION
## Summary
- fix dynamic params usage in `QuotationDetailPage`

## Testing
- `npm test` within `backend` *(fails: ERR_ASSERTION / ENOENT)*
- `npm test` within `client` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684c1c77bda083258b97f86e13733876