### PR TITLE
Fix quotation save with backend

### DIFF
--- a/backend/test/matchExcel.test.js
+++ b/backend/test/matchExcel.test.js
@@ -2,15 +2,31 @@ import assert from 'node:assert/strict';
 import { spawnSync } from 'child_process';
 import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
+import fs from 'fs';
+import XLSX from 'xlsx';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const cwd = path.resolve(__dirname, '..');
 
+// Create a temporary input workbook so tests do not rely on external files
+const tmpInput = path.resolve(__dirname, 'tmpInput.xlsx');
+const wb = XLSX.utils.book_new();
+const ws = XLSX.utils.aoa_to_sheet([
+  ['Description', 'Qty', 'Rate', 'Unit'],
+  ['Test item', 1, 10, 'm']
+]);
+XLSX.utils.book_append_sheet(wb, ws, 'Sheet1');
+XLSX.writeFile(wb, tmpInput);
+assert.ok(fs.existsSync(tmpInput));
+
 const proc = spawnSync('node', [
   'scripts/matchExcel.js',
   'MJD-PRICELIST.xlsx',
-  '../frontend/Input.xlsx'
+  tmpInput
 ], { encoding: 'utf8', cwd });
+
+// Clean up the temporary file if it exists
+try { fs.unlinkSync(tmpInput); } catch { /* ignore */ }
 
 assert.strictEqual(proc.status, 0);
 const lines = proc.stdout.trim().split('\n');

--- a/backend/test/matchService.test.js
+++ b/backend/test/matchService.test.js
@@ -2,13 +2,25 @@ import assert from 'node:assert/strict';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import XLSX from 'xlsx';
 import { matchFromFiles } from '../src/services/matchService.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pricePath = path.resolve(__dirname, '../MJD-PRICELIST.xlsx');
-const inputBuf = fs.readFileSync(path.resolve(__dirname, '../../frontend/Input.xlsx'));
+// Generate a temporary input workbook so the test is self-contained
+const tmpInput = path.resolve(__dirname, 'tmpInput.xlsx');
+const wb = XLSX.utils.book_new();
+const ws = XLSX.utils.aoa_to_sheet([
+  ['Description', 'Qty', 'Rate', 'Unit'],
+  ['Test item', 2, 15, 'm']
+]);
+XLSX.utils.book_append_sheet(wb, ws, 'Sheet1');
+XLSX.writeFile(wb, tmpInput);
+const inputBuf = fs.readFileSync(tmpInput);
 
 const results = matchFromFiles(pricePath, inputBuf);
+
+fs.unlinkSync(tmpInput);
 
 assert.ok(Array.isArray(results));
 assert.ok(results.length > 0);

--- a/client/components/price-match-module.tsx
+++ b/client/components/price-match-module.tsx
@@ -330,8 +330,8 @@ export function PriceMatchModule({ onMatched }: PriceMatchModuleProps) {
       date: new Date().toISOString(),
       items
     }
-    await saveQuotation(quotation)
-    return quotation.id
+    const saved = await saveQuotation(quotation)
+    return saved.id
   }
 
   const handleDeleteRow = (index: number) => {
@@ -369,7 +369,13 @@ export function PriceMatchModule({ onMatched }: PriceMatchModuleProps) {
       alert('Project and client name are required')
       return
     }
-    const id = await saveQuotationData(results, autoQuoteId || undefined)
+    let id: string
+    try {
+      id = await saveQuotationData(results, autoQuoteId || undefined)
+    } catch (err: any) {
+      alert(err.message || 'Save failed')
+      return
+    }
     setAutoQuoteId(id)
     const items = results.map((r, idx) => {
       const sel = typeof r.selected === 'number' ? r.matches[r.selected] : null

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -1,4 +1,5 @@
-const base = process.env.NEXT_PUBLIC_API_URL ?? "";
+// Default to local backend when env var is not set
+const base = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
 
 export async function loginUser(email: string, password: string) {
   const res = await fetch(`${base}/api/auth/login`, {

--- a/client/lib/quotation-store.ts
+++ b/client/lib/quotation-store.ts
@@ -17,7 +17,8 @@ export interface Quotation {
   items: QuotationItem[]
 }
 
-const base = process.env.NEXT_PUBLIC_API_URL ?? ''
+// Default to local backend if env var not provided
+const base = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000'
 
 export async function loadQuotations(): Promise<Quotation[]> {
   const res = await fetch(`${base}/api/quotations`, { cache: 'no-store' })
@@ -25,12 +26,17 @@ export async function loadQuotations(): Promise<Quotation[]> {
   return (await res.json()) as Quotation[]
 }
 
-export async function saveQuotation(q: Quotation) {
-  await fetch(`${base}/api/quotations`, {
+export async function saveQuotation(q: Quotation): Promise<Quotation> {
+  const res = await fetch(`${base}/api/quotations`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(q),
   })
+  if (!res.ok) {
+    const msg = await res.text()
+    throw new Error(`Save failed: ${msg}`)
+  }
+  return res.json() as Promise<Quotation>
 }
 
 export async function getQuotation(id: string): Promise<Quotation | undefined> {


### PR DESCRIPTION
## Summary
- default to local backend URL when NEXT_PUBLIC_API_URL isn't set
- return saved quotation and handle failures when saving
- improve error handling in price match module
- create temporary worksheets in tests to avoid missing files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684c1da48a7c8325a36b5f439011fd65