### PR TITLE
Fix themeColor export

### DIFF
--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -19,7 +19,6 @@ export const metadata: Metadata = {
   title: "BOQ Pricing Pro",
   description: "Premium quotation management for construction projects",
   manifest: "/manifest.json",
-  themeColor: "#000000",
   appleWebApp: {
     capable: true,
     statusBarStyle: "black-translucent",
@@ -42,6 +41,7 @@ export const viewport: Viewport = {
   minimumScale: 1,
   userScalable: true,
   viewportFit: "cover",
+  themeColor: "#000000",
 }
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- move `themeColor` setting from `metadata` export to the viewport export

## Testing
- `npm test` in `backend`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_b_684c1fc2e29c8325b204fab3db56bf46